### PR TITLE
Wrong condition

### DIFF
--- a/src/TemplateReport.php
+++ b/src/TemplateReport.php
@@ -303,7 +303,7 @@ class TemplateReport extends Component
         $doc = self::FORMAT_WORD;
         $pdf = self::FORMAT_PDF;
         $both = self::FORMAT_BOTH;
-        if ($this->format !== $doc || $this->format !== $pdf || $this->format !== $both) {
+        if ($this->format !== $doc && $this->format !== $pdf && $this->format !== $both) {
             throw new InvalidConfigException("Format must be either '{$doc}' or '{$pdf}' or '{$both}'");
         }
         $this->setTemplate();


### PR DESCRIPTION
Wrong condition when comparing formats

## Scope
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

## Changes
The following changes were made (this change is also documented in the [change log](https://github.com/kartik-v/yii2-word-report/blob/master/CHANGE.md)):

- TemplateReport.php has wrong condition when comparing formats

## Related Issues
If this is related to an existing ticket, include a link to it as well.